### PR TITLE
Removed seperate docker compose installation

### DIFF
--- a/docs/20_installation.md
+++ b/docs/20_installation.md
@@ -133,21 +133,10 @@ Docker itself already provides a very good script:
 curl -fsSL https://get.docker.com | sudo bash
 ```
 
-Finally, you need to install Docker Compose:
+Instead of typing `sudo docker compose up -d` all the time you can use this alias and type `dc up -d`:
 
 ```shell
-sudo curl -L -o /usr/local/bin/docker-compose \
-  "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)"
-sudo chmod +x /usr/local/bin/docker-compose
-```
-On an ARM Maschine you need:
-```shell
-pip install docker-compose
-```
-Instead of typing `sudo docker-compose up -d` all the time you can use this alias and type `dc up -d`:
-
-```shell
-echo 'alias dc="sudo docker-compose "' >> ~/.bashrc
+echo 'alias dc="sudo docker compose "' >> ~/.bashrc
 ```
 
 ## DNS Setup


### PR DESCRIPTION
[Docker Compose](https://github.com/docker/compose) is intigrated into the `docker` command as a subcommand `docker compose`.

Docker Compose has releases for arm64/armv7, so the `pip` command isn't needed anymore.